### PR TITLE
Better handle case where g_speak_home not found

### DIFF
--- a/obi/obi.py
+++ b/obi/obi.py
@@ -81,16 +81,17 @@ def get_g_speak_home(arguments):
         set_by = "environment variable G_SPEAK_HOME"
     else:
         path = os.path.join(os.path.sep, "opt", "oblong")
-        items = [os.path.join(path, item) for item in os.listdir(path) if "g-speak" in item]
-        items = [item for item in items if os.path.isdir(item)]
-        items.sort()
-        # the last element will be the directory with the most recent
-        # version of g-speak
-        if not items is None:
+        try:
+            items = [os.path.join(path, item) for item in os.listdir(path) if "g-speak" in item]
+            items = [item for item in items if os.path.isdir(item)]
+            items.sort()
+            # the last element will be the directory with the most recent
+            # version of g-speak
             g_speak_home = items[-1]
             set_by = "directory lookup"
-        else:
-            print("Could not find the g_speak home directory")
+        except (OSError, IndexError):
+            print("Could not find the g_speak home directory in {}"
+                  .format(path))
             print("Run new again and specify: --g_speak_home=/path/to/g-speak")
             sys.exit(1)
 


### PR DESCRIPTION
Previously, if you had an /opt/oblong directory, but no g-speakX.Y entries in it
that looked good, you'd get a nasty error message:
https://github.com/Oblong/obi/pull/39#issuecomment-197366819

Similarly, if you didn't have an /opt/oblong directory at all, you'd get
an OSError from the call to os.listdir.