### PR TITLE
Skip tee when running locally

### DIFF
--- a/obi/task/task.py
+++ b/obi/task/task.py
@@ -104,7 +104,7 @@ def room_task(room_name, task_name=None):
                     print(fabric.colors.green(cmd.rstrip(), bold=True))
         env.print_cmds = print_shell_script
         env.relpath = os.path.relpath
-        env.launch_format_str = "{0} {1} 2>&1 | tee -a {2}"
+        env.launch_format_str = "{0} {1}"
         env.debug_launch_format_str = "{0} {1} {2}"
     else:
         env.user = room.get("user", env.local_user) # needed for remote run


### PR DESCRIPTION
Experience has shown that obi users very rarely check the log file after
local runs.  The rsync from an `obi build` or `obi go` may also
overwrite logs on remote machines with logs from the local machine.

`tee` also kept Oblong's internal logging system from
printing colors, so this also closes #34.