### PR TITLE
Clean up seeking for g-speak home

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ brew upgrade obi
 sudo apt-get install python-dev python-pip
 
 # Install
-
+# NOTE: You should make sure that ~/.local/bin is on your PATH if using the
+# --user flag.
 pip install --user git+https://github.com/Oblong/obi.git
 
 # Upgrading


### PR DESCRIPTION
- Sorting the whole list just for the largest element is unnecessary,
  just use max()
- We can do better than a lexicographic sort; distutils includes some
  nice utilities for sorting by version number, so use those.  This
  heads off a version of the "Windows 9" problem.
  https://searchcode.com/?q=if%28version%2Cstartswith%28%22windows+9%22%29
