### PR TITLE
change default rsync flags to copy symlinked content

### DIFF
--- a/obi/task/task.py
+++ b/obi/task/task.py
@@ -267,7 +267,7 @@ def rsync_task():
         remote_dir=env.project_dir,
         delete=True,
         exclude=env.config.get("rsync-excludes", []),
-        extra_opts=env.config.get("rsync-extra-opts", "-K"),
+        extra_opts=env.config.get("rsync-extra-opts", "--copy-links --partial"),
         capture=True)
 
 def parent_dir(current_dir):


### PR DESCRIPTION
In #37, the `-K` flag was added, which does some symlinky stuff. However, it does not copy all symlinked-in files and directories to remote destinations. This changes that flag to`--copy-links`, which causes rsync to copy that symlinked content to the destination.

Additionally, the `--partial` flag will resume partially transferred files instead of clobbering the partial content.