### PR TITLE
swap config's launchargs to come before obi's extra arguments

### DIFF
--- a/obi/task/task.py
+++ b/obi/task/task.py
@@ -215,8 +215,8 @@ def launch_task(debugger, extras):
 
     formatted_launch = "{0} {1} {2}".format(
         target, # {0}
-        " ".join(extras), # {1}
-        " ".join(launch_args) # {2}
+        " ".join(launch_args), # {1}
+        " ".join(extras) # {2}
     )
 
     env_vars = env.config.get("env-vars", {})


### PR DESCRIPTION
Most users probably expect that `obi go -- --something-extra` results in that `--something-extra` flag to be passed to their program at the end, their intuition following `obi go` expands into `myprogram --launch-args=one --launch-args-two=three --something-extra` and not that the extra flag come before the list of arguments specified in the project.yaml.
https://github.com/Oblong/obi/issues/99
https://github.com/Oblong/obi/issues/65