### PR TITLE
add optional --force flag for obi stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project does not use semver.
 ## [Unreleased]
 ### Added
 - Add command completion for bash
+- Add optional flag --force (-f for short) to `obi stop` to send a SIGKILL message instead of the usual SIGTERM
 
 ## [3.2.0] - 2016-01-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ project files to /tmp/yourusername/project-name/ on the machines of that room.
 
 Usage:
   obi go [<room>] [--debug=<debugger>] [--dry-run] [--] [<extras>...]
-  obi stop [<room>] [--dry-run]
+  obi stop [<room>] [-f|--force] [--dry-run]
   obi build [<room>] [--dry-run]
   obi clean [<room>] [--dry-run]
   obi rsync <room> [--dry-run]
@@ -201,7 +201,8 @@ obi go room --debug="apitrace trace"
 
 ### obi stop [room-name]
 ---
-`obi stop [<room-name>]` stops the application. If `<room-name>` is not specified, then the application is stopped on the local machine.
+`obi stop [<room-name>]` stops the application. If `<room-name>` is not specified, then the application is stopped on the local machine. The `[-f|--force]` option
+will send a stronger message, such as SIGKILL.
 
 #### example
 ```bash
@@ -209,6 +210,8 @@ obi go room --debug="apitrace trace"
 obi stop
 # Stop the application on the host machines listed under the room named room
 obi stop room
+# Forcefully stop the application on remote hosts for the room named room
+obi stop room -f
 ```
 
 ### obi build [room-name]

--- a/obi/obi.py
+++ b/obi/obi.py
@@ -25,7 +25,7 @@ project files to /tmp/yourusername/project-name/ on the machines of that room.
 
 Usage:
   obi go [<room>] [--debug=<debugger>] [--dry-run] [--] [<extras>...]
-  obi stop [<room>] [--dry-run]
+  obi stop [<room>] [-f|--force] [--dry-run]
   obi build [<room>] [--dry-run]
   obi clean [<room>] [--dry-run]
   obi rsync <room> [--dry-run]
@@ -128,6 +128,7 @@ def main():
     if sys.argv[1:] == ["wan"]:
         return subprocess.call(["telnet", "towel.blinkenlights.nl"])
 
+
     # defaults for the template subcommands
     default_base_template_dir = os.path.join(os.path.expanduser("~"), ".local/share")
     default_obi_template_dir = os.path.join(
@@ -187,7 +188,7 @@ def main():
             pass
     elif arguments['stop']:
         res = fabric.api.execute(task.room_task, room, "stop")
-        res.update(fabric.api.execute(task.stop_task))
+        res.update(fabric.api.execute(task.stop_task, arguments["--force"] or arguments["-f"]))
     elif arguments['clean']:
         res = fabric.api.execute(task.room_task, room, "clean")
         res.update(fabric.api.execute(task.clean_task))

--- a/obi/task/task.py
+++ b/obi/task/task.py
@@ -150,7 +150,7 @@ def clean_task():
 
 @task
 @parallel
-def stop_task():
+def stop_task(force=False):
     """
     obi stop
     """
@@ -162,7 +162,10 @@ def stop_task():
     with env.cd(env.project_dir):
         for cmd in env.config.get("local-pre-stop-cmds", []):
             local(cmd)
-    default_stop = "pkill -SIGTERM -f '[a-z/]+{0} .*' || true".format(env.target_name)
+    signal = "SIGTERM"
+    if force:
+      signal = "SIGKILL"
+    default_stop = "pkill -{0} -f '[a-z/]+{1} .*' || true".format(signal, env.target_name)
     stop_cmd = env.config.get("stop-cmd", default_stop)
     env.run(stop_cmd)
     with env.cd(env.project_dir):


### PR DESCRIPTION
This commit adds an optional `--force` flag to `obi stop` with a `-f` short form. Using `--force` issues a SIGKILL instead of a SIGTERM.