### PR TITLE
fixes for bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,27 @@ eval "$(ssh-agent -s)"
 ssh-add -K ~/.ssh/id_rsa
 ```
 
+## Bash command completion
+
+obi ships with a tab-completion script for bash. When you install obi with homebrew,
+the script is installed to `/usr/local/etc/bash_completion.d/obi`. Add a snippet
+like the following to your preferred bash config file:
+```bash
+if [ -f /usr/local/etc/bash_completion.d/obi ]; then
+  source /usr/local/etc/bash_completion.d/obi
+fi
+```
+zsh users can use the same file, by adding a similar snippet to their `.zshrc`:
+```zsh
+if [ -f /usr/local/etc/bash_completion.d/obi ]; then
+  autoload bashcompinit
+  bashcompinit
+  source /usr/local/etc/bash_completion.d/obi
+fi
+```
+If you installed obi by using `pip`, you will need to install the command completion
+script manually.
+
 ## Editor tips
 
 ### emacs

--- a/obi-bash-completion.sh
+++ b/obi-bash-completion.sh
@@ -201,38 +201,7 @@ _obi_installed_templates ()
 
 _obi_roomnames()
 {
-  python - <<EOF
-import os
-import yaml
-def parent_dir(current_dir):
-    return os.path.abspath(os.path.join(current_dir, os.pardir))
-
-def load_project_config(config_path):
-    try:
-        with open(config_path) as config_file:
-            config = yaml.load(config_file)
-            if not config:
-                abort("Error: problem loading " + project_config_file)
-            return config
-    except Exception as e:
-        abort("Cannot load project.yaml file at {0}\nException: {1}".format(config_path, e))
-
-def project_yaml():
-    current = os.getcwd()
-    parent = parent_dir(current)
-    while current != parent:
-        test_file = os.path.join(current, "project.yaml")
-        if os.path.exists(test_file):
-            return os.path.abspath(test_file)
-        else:
-            current = parent
-            parent = parent_dir(current)
-    abort("Could not find the project.yaml file in {0} or any parent directories".format(os.getcwd()))
-
-projectyaml = load_project_config(project_yaml())
-for k in sorted(projectyaml['rooms'].keys()) :
-  print k
-EOF
+  echo $(obi room list)
 }
 
 complete -F _obi obi

--- a/obi/obi.py
+++ b/obi/obi.py
@@ -18,6 +18,8 @@ template install  Install an obi template
 template remove   Remove an installed obi template
 template upgrade  Upgrade an installed obi template
 
+room list         List available rooms
+
 Edit project.yaml (in your project folder) to configure sets of machines for
 go/stop, set arguments for building and launching the program, and choose feld &
 screen proteins. By default, running your application in a room will deploy
@@ -35,6 +37,7 @@ Usage:
   obi template install <giturl> [<name>] [--template_home=<path>]
   obi template remove <name> [--template_home=<path>]
   obi template upgrade <name> [--template_home=<path>]
+  obi room list
   obi -h | --help | --version
 
 Options:
@@ -252,7 +255,12 @@ def main():
             else:
                 print("No template installed with name " + template_name)
                 return 1
-
+    elif arguments['room']:
+        if arguments['list']:
+            # converts project.yaml into Dict
+            config = task.load_project_config(task.project_yaml())
+            for room in sorted(config.get("rooms", {})):
+                print(room)
     return 0
 
 if __name__ == '__main__':

--- a/obi/task/__init__.py
+++ b/obi/task/__init__.py
@@ -1,1 +1,1 @@
-from obi.task.task import (dryrun, build_task, clean_task, fetch_task, stop_task, launch_task, room_task)
+from obi.task.task import (dryrun, build_task, clean_task, fetch_task, stop_task, launch_task, room_task, project_yaml, load_project_config)


### PR DESCRIPTION
This PR adds instructions to the README to use the bash (and zsh) completion.

This PR also changes the way the completion scripts find what rooms are valid. A new command is added to obi: `obi room list`. This command finds the project.yaml and prints out the rooms specified. The bash script is changed to rely on this new command, instead of trying to execute some python. This change fixes #108.