### PR TITLE
fix stop regex to handle parameterless apps

### DIFF
--- a/obi/task/task.py
+++ b/obi/task/task.py
@@ -213,7 +213,7 @@ def stop_task(force=False):
     # temporarily ignore above code and issue signal to env.target_name because
     # target_regex won't hit webthing-enabled projects due to shell wrapper
     if env.target_name:
-        default_stop = "pkill -{0} -f '[a-z/]+{1} ' || true".format(signal, env.target_name)
+        default_stop = "pkill -{0} -f '[a-z/]+{1}([[:space:]]|$)' || true".format(signal, env.target_name)
     else:
         default_stop = "echo 'no pkill command issued because target=\"\"'"
     stop_cmd = env.config.get("stop-cmd", default_stop)


### PR DESCRIPTION
Obi used a space in the pkill regex as a poor man's word boundary match.
Now we match on space or end of line, so if your app has no arguments it
can still be stopped.
https://github.com/Oblong/obi/issues/144