### PR TITLE
filter out apple ld warnings about out of sync files

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,5 +1,10 @@
 # Hacking on obi
 
+## Dependencies
+
+    pip install docopt==0.6.2' fabric==1.10.3' jinja2==2.8' pyyaml==3.11
+
+
 ## Tips
 
 When developing obi, you may want to test your changes with a real world

--- a/obi/task/task.py
+++ b/obi/task/task.py
@@ -153,6 +153,11 @@ def build_task():
             # cmake (unless cmake-args, and therefore sentinel_hash, changes).
             # See issue #38 and issue #120
             sentinel_path = env.build_dir + "/hello-obi.txt"
+            # this is a work-around for an apple bug to filter out the resulting
+            # ugly linker warnings:
+            # See issue 150 or:
+            # https://forums.developer.apple.com/thread/97850
+            warning_filter="ld: warning: text-based stub file"
             # translation from shell to pseudocode:
             #   * if the contents of SENTINEL_PATH match SENTINEL_HASH, do nothing
             #   * else, run cmake with cmake-args and write SENTINEL_HASH to SENTINEL_PATH
@@ -165,7 +170,8 @@ def build_task():
                     cmake_args=cmake_args,
                     sentinel_path=shlexquote(sentinel_path),
                     sentinel_hash=sentinel_hash))
-            env.run("cmake --build {0} -- {1}".format(shlexquote(env.build_dir), build_args))
+            env.run("cmake --build {0} -- {1} 2>&1 | grep -v \"{2}\"".
+                format(shlexquote(env.build_dir), build_args, warning_filter))
 
 @task
 @parallel


### PR DESCRIPTION
Closes #150

Linking against any framework spews benign "out of sync"
warnings with the latest command line tools, see

- https://forums.developer.apple.com/thread/97850
- https://openradar.appspot.com/45171575